### PR TITLE
Add code execution data preparation script

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,20 @@
+# Datasets
+
+## Code execution tasks
+
+The script `finetuning/sft/prepare_code_execution_data.py` collects prompt/solution pairs from open-source repositories. It scans Python files for comments formatted as:
+
+```
+# prompt: describe the task
+# solution: expected answer
+```
+
+### Usage
+
+Run the script with a list of repository URLs and an output path:
+
+```
+python finetuning/sft/prepare_code_execution_data.py --repos https://github.com/user/repo1 https://github.com/user/repo2 --output datasets/code_tasks.jsonl
+```
+
+Repositories are cloned into the `external_repos` directory by default. The resulting JSONL file contains entries with `prompt` and `solution` keys suitable for fine-tuning.

--- a/finetuning/sft/prepare_code_execution_data.py
+++ b/finetuning/sft/prepare_code_execution_data.py
@@ -1,0 +1,108 @@
+import argparse
+import json
+import logging
+import re
+import subprocess
+from pathlib import Path
+from urllib.parse import urlparse
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+PROMPT_RE = re.compile(r"#\s*prompt:(.*)", re.IGNORECASE)
+SOLUTION_RE = re.compile(r"#\s*solution:(.*)", re.IGNORECASE)
+
+
+def extract_tasks_from_file(path: Path):
+    """Extract prompt/solution pairs from a file.
+
+    The function searches for comment lines following the pattern::
+
+        # prompt: <description>
+        # solution: <expected answer>
+
+    Args:
+        path: Path to the source file.
+
+    Returns:
+        A list of dictionaries with ``prompt`` and ``solution`` keys.
+    """
+
+    tasks = []
+    with path.open("r", encoding="utf-8") as file:
+        lines = file.readlines()
+
+    prompt = None
+    for line in lines:
+        prompt_match = PROMPT_RE.match(line)
+        if prompt_match:
+            prompt = prompt_match.group(1).strip()
+            continue
+        if prompt is not None:
+            solution_match = SOLUTION_RE.match(line)
+            if solution_match:
+                solution = solution_match.group(1).strip()
+                tasks.append({"prompt": prompt, "solution": solution})
+                prompt = None
+
+    return tasks
+
+
+def clone_repo(url: str, workdir: Path) -> Path:
+    """Clone a git repository if it does not exist."""
+    repo_name = urlparse(url).path.split("/")[-1].replace(".git", "")
+    dest = workdir / repo_name
+    if dest.exists():
+        logger.info("Repository %s already exists, skipping clone", url)
+    else:
+        subprocess.run(["git", "clone", url, str(dest)], check=True)
+    return dest
+
+
+def collect_from_repo(repo_path: Path):
+    """Collect tasks from all Python files in a repository."""
+    tasks = []
+    for path in repo_path.rglob("*.py"):
+        tasks.extend(extract_tasks_from_file(path))
+    return tasks
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect prompt/solution pairs from open repositories",
+    )
+    parser.add_argument(
+        "--repos",
+        nargs="+",
+        required=True,
+        help="Git repository URLs to process",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to output JSONL file",
+    )
+    parser.add_argument(
+        "--workdir",
+        default="external_repos",
+        help="Directory where repositories will be cloned",
+    )
+    args = parser.parse_args()
+
+    workdir = Path(args.workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    all_tasks = []
+    for repo_url in args.repos:
+        repo_path = clone_repo(repo_url, workdir)
+        all_tasks.extend(collect_from_repo(repo_path))
+
+    with open(args.output, "w", encoding="utf-8") as outfile:
+        for task in all_tasks:
+            outfile.write(json.dumps(task, ensure_ascii=False) + "\n")
+
+    logger.info("Wrote %d tasks to %s", len(all_tasks), args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add utility to collect prompt/solution tasks from git repositories
- document dataset generation workflow

## Testing
- `flake8 finetuning/sft/prepare_code_execution_data.py`
- `pytest` *(fails: expected call not found; connection error; assert '[liquid fallback]' in response)*

------
https://chatgpt.com/codex/tasks/task_e_688eb7f653008329895a935bd6f20c1e