### PR TITLE
Implement token-based entropy logging with perplexity

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,15 +1,16 @@
-from arianna_chain import ThoughtComplexityLogger, estimate_complexity_and_entropy
+from arianna_chain import ThoughtComplexityLogger, estimate_complexity_and_entropy, tokenizer
 
 
 def test_estimate_complexity_and_entropy_keywords():
     msg = "This is a paradox that asks why it is recursive"
-    complexity, entropy = estimate_complexity_and_entropy(msg)
-    assert complexity >= 3
+    tokens, entropy, _ = estimate_complexity_and_entropy(msg)
+    assert tokens == len(tokenizer.encode(msg))
     assert 0 <= entropy <= 1
 
 
 def test_logger_records_and_recent():
     logger = ThoughtComplexityLogger(log_file="logs/test_log.jsonl")
     entry = logger.log_turn("test message", 2, 0.5)
-    assert entry.complexity == 2
+    assert entry.tokens == 2
+    assert entry.perplexity is None
     assert logger.recent(1)[0].message == "test message"

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -21,7 +21,7 @@ def _patch_env():
         patch("arianna_chain.quantize_2bit"),
         patch(
             "arianna_chain.thought_logger.log_turn",
-            return_value=SimpleNamespace(complexity=1, entropy=0.1, timestamp="t"),
+            return_value=SimpleNamespace(tokens=1, entropy=0.1, perplexity=None, timestamp="t"),
         ),
     )
 


### PR DESCRIPTION
## Summary
- use n-gram-based Shannon entropy and token counts for complexity estimates
- store tokens, entropy, and optional perplexity in `ThoughtComplexityLogger`
- update reflection tests and logger tests for new metrics

## Testing
- `flake8 arianna_chain.py tests/test_logger.py tests/test_reflection.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ed786c5c88329a72f267d7d15ac19