### PR TITLE
Add reward scoring utilities and integrate into pipeline

### DIFF
--- a/arianna_chain.py
+++ b/arianna_chain.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from typing import List, Tuple, Optional, Dict, Any, Iterable, Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+from rewards import format_reward, reasoning_steps_reward
+
 import requests
 import torch
 import torch.nn as nn
@@ -803,6 +805,12 @@ def reason_loop(
             step_obj["tokens_used"] = obj["tokens_used"]
         if act: step_obj["action"] = act
         if observation: step_obj["observation"] = observation
+
+        resp_text = f"<think>{think}</think>\n<answer>{answer}</answer>"
+        fmt_score = format_reward(resp_text)
+        steps_score = reasoning_steps_reward(resp_text)
+        step_obj["rewards"] = {"format": fmt_score, "reasoning_steps": steps_score}
+        sm.log("<reward>", json.dumps({"step": step_idx, "format": fmt_score, "reasoning_steps": steps_score}))
 
         sm.log("<step>", json.dumps(step_obj, ensure_ascii=False))
         steps.append(step_obj)

--- a/finetuning/sft/prepare_code_execution_data.py
+++ b/finetuning/sft/prepare_code_execution_data.py
@@ -6,6 +6,8 @@ import subprocess
 from pathlib import Path
 from urllib.parse import urlparse
 
+from rewards import format_reward, reasoning_steps_reward
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -99,6 +101,17 @@ def main():
 
     with open(args.output, "w", encoding="utf-8") as outfile:
         for task in all_tasks:
+            text = f"<think>{task['prompt']}</think>\n<answer>{task['solution']}</answer>"
+            fmt_score = format_reward(text)
+            steps_score = reasoning_steps_reward(text)
+            task["format_reward"] = fmt_score
+            task["reasoning_steps_reward"] = steps_score
+            logger.info(
+                "Rewards for %s: format=%.2f reasoning=%.2f",
+                task["prompt"][:30],
+                fmt_score,
+                steps_score,
+            )
             outfile.write(json.dumps(task, ensure_ascii=False) + "\n")
 
     logger.info("Wrote %d tasks to %s", len(all_tasks), args.output)

--- a/rewards.py
+++ b/rewards.py
@@ -1,0 +1,36 @@
+import re
+
+
+def format_reward(text: str) -> float:
+    """Return 1.0 if text contains single <think>/<answer> blocks in order.
+
+    The function checks that the response includes exactly one <think>...</think>
+    block followed by one <answer>...</answer> block. If the format is not
+    respected, ``0.0`` is returned.
+    """
+    think_blocks = re.findall(r"<think>(.*?)</think>", text, flags=re.DOTALL)
+    answer_blocks = re.findall(r"<answer>(.*?)</answer>", text, flags=re.DOTALL)
+    if len(think_blocks) != 1 or len(answer_blocks) != 1:
+        return 0.0
+    think_pos = text.find("<think>")
+    answer_pos = text.find("<answer>")
+    return 1.0 if 0 <= think_pos < answer_pos else 0.0
+
+
+def reasoning_steps_reward(text: str) -> float:
+    """Return 1.0 if at least three numbered/bulleted steps exist in <think>.
+
+    The function inspects the content of the <think> block and counts lines
+    starting with a number, ``-`` or ``*``. A reward of ``1.0`` is given when at
+    least three such lines are found, otherwise ``0.0``.
+    """
+    match = re.search(r"<think>(.*?)</think>", text, flags=re.DOTALL)
+    if not match:
+        return 0.0
+    think_content = match.group(1)
+    lines = [line.strip() for line in think_content.splitlines()]
+    count = 0
+    for line in lines:
+        if re.match(r"^(\d+\.\s+|-\s+|\*\s+)", line):
+            count += 1
+    return 1.0 if count >= 3 else 0.0


### PR DESCRIPTION
## Summary
- implement new `format_reward` and `reasoning_steps_reward` helpers to validate `<think>/<answer>` layout and numbered reasoning
- log reward scores during reasoning loop and data preparation scripts

## Testing
- `flake8 rewards.py arianna_chain.py finetuning/sft/prepare_code_execution_data.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ed5f25b608329b210898b890fa49e