### PR TITLE
Add reasoning tag validation and reward helper

### DIFF
--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -13,7 +13,27 @@ from arianna_chain import (
     reason_loop,
     tree_reason_loop,
     tokenizer,
+    validate_reasoning_tags,
+    ThoughtComplexityLogger,
 )
+
+
+def test_validate_reasoning_tags_valid() -> None:
+    txt = "<think>reason</think><answer>result</answer>"
+    assert validate_reasoning_tags(txt)
+
+
+def test_validate_reasoning_tags_invalid() -> None:
+    txt = "<think>oops<answer>missing close</answer>"
+    assert not validate_reasoning_tags(txt)
+
+
+def test_log_turn_flags_invalid_tags(tmp_path) -> None:
+    logger = ThoughtComplexityLogger(log_file=tmp_path / "log.jsonl")
+    good = logger.log_turn("<think>a</think><answer>b</answer>", 1, 0.0)
+    bad = logger.log_turn("no tags here", 1, 0.0)
+    assert good.valid_tags is True
+    assert bad.valid_tags is False
 
 
 def test_generate_with_think_returns_thought_and_final() -> None:


### PR DESCRIPTION
## Summary
- validate `<think>/<answer>` structure with new `validate_reasoning_tags`
- expose `reasoning_steps_reward` helper for counting reasoning segments
- flag malformed reasoning traces in `ThoughtComplexityLogger`
- test tag validation and logging behaviour

## Testing
- `flake8`
- `flake8 arianna_chain.py tests/test_reasoning.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688edafc4aec83299bba68e05bf4c493