### PR TITLE
Add sandboxed code execution tool

### DIFF
--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -13,6 +13,7 @@ from arianna_chain import (
     reason_loop,
     tree_reason_loop,
     tokenizer,
+    _tool_code_exec,
 )
 
 
@@ -127,3 +128,15 @@ def test_gsm8k_subset_accuracy() -> None:
 
     accuracy = correct / len(samples)
     assert accuracy == 1.0
+
+
+def test_tool_code_exec_stdout_and_stderr() -> None:
+    res = json.loads(_tool_code_exec("import sys;\nprint(1+1);\nsys.stderr.write('err\\n')"))
+    assert res["stdout"].strip() == "2"
+    assert res["stderr"].strip() == "err"
+
+
+def test_tool_code_exec_error_handling() -> None:
+    res = json.loads(_tool_code_exec("1/0"))
+    assert not res["ok"]
+    assert "ZeroDivisionError" in res["stderr"]


### PR DESCRIPTION
## Summary
- add `code.exec` tool to run Python snippets in a resource-limited subprocess and expose stdout/stderr
- document new tool in `_tools_manifest`
- test basic execution and error handling

## Testing
- `flake8 arianna_chain.py tests/test_reasoning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688edb36327483299a0275d60cf7cf2e