### PR TITLE
Add GRPO training script for Arianna-C

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ The test loads each question, queries the model, and reports the final
 accuracy. Replace the dataset or hook in a different generation function to
 benchmark other models.
 
+## GRPO Training
+
+A minimal GRPO loop is available for reward-based fine-tuning. It reads a
+JSONL dataset of ``prompt``/``solution`` pairs and logs rewards for accuracy,
+reasoning tags and output length.
+
+```bash
+python finetuning/grpo_train.py --dataset datasets/gsm8k_subset.jsonl --epochs 3 --save-every 50
+```
+
+Checkpoints and training logs are stored under ``logs/grpo/``.
+
 ## 🧬 System Prompt
 
 Arianna-C loads the following core prompt at startup. If no prompt is provided, this voice becomes the default:

--- a/finetuning/grpo_train.py
+++ b/finetuning/grpo_train.py
@@ -1,0 +1,157 @@
+"""GRPO training loop for Arianna-C.
+
+This script is inspired by `open_r1`'s implementation of Generalized
+Rejection Policy Optimization but adapts the idea to the tiny Arianna-C
+model. It combines simple reward functions—accuracy, reasoning tags and
+length—to fine-tune the model.
+"""
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import torch
+
+from arianna_chain import AriannaC, AriannaCConfig, tokenizer
+
+
+DEFAULT_LOGDIR = Path("logs/grpo")
+DEFAULT_LOGDIR.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger("grpo")
+logger.setLevel(logging.INFO)
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+_file_handler = logging.FileHandler(DEFAULT_LOGDIR / "train.log")
+_file_handler.setFormatter(formatter)
+_stream_handler = logging.StreamHandler()
+_stream_handler.setFormatter(formatter)
+logger.addHandler(_file_handler)
+logger.addHandler(_stream_handler)
+
+
+def load_dataset(path: str) -> List[Dict[str, str]]:
+    """Load a JSONL dataset with ``prompt``/``solution`` style entries."""
+    items: List[Dict[str, str]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                items.append(json.loads(line))
+    return items
+
+
+def accuracy_reward(pred: str, target: str) -> float:
+    """Return 1.0 if ``pred`` exactly matches ``target`` (after stripping)."""
+    return 1.0 if pred.strip() == target.strip() else 0.0
+
+
+def reasoning_tag_reward(text: str) -> float:
+    """Reward presence of both <analysis> and <final> tags."""
+    has_analysis = "<analysis>" in text
+    has_final = "<final>" in text
+    return 1.0 if has_analysis and has_final else 0.0
+
+
+def length_reward(text: str, max_tokens: int) -> float:
+    """Penalty for outputs longer than ``max_tokens`` tokens."""
+    toks = text.split()
+    penalty = max(0, len(toks) - max_tokens)
+    return -penalty / max_tokens
+
+
+def load_model(model_path: str | None) -> AriannaC:
+    """Load ``AriannaC`` from a checkpoint or initialize a new one."""
+    config = AriannaCConfig(apply_quant=False)
+    model = AriannaC(config)
+    model.train()
+    torch.set_grad_enabled(True)
+    if model_path and Path(model_path).exists():
+        state = torch.load(model_path, map_location="cpu")
+        model.load_state_dict(state)
+        logger.info("Loaded model weights from %s", model_path)
+    return model
+
+
+def sample_with_grad(
+    model: AriannaC, idx: torch.Tensor, max_new_tokens: int, temperature: float
+) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+    """Sample tokens while keeping gradients."""
+    log_probs: List[torch.Tensor] = []
+    for _ in range(max_new_tokens):
+        logits, _ = model(idx[:, -model.block_size:])
+        logits = logits[:, -1, :]
+        probs = torch.softmax(logits / temperature, dim=-1)
+        next_token = torch.multinomial(probs, num_samples=1)
+        log_prob = torch.log(probs.gather(1, next_token))
+        idx = torch.cat((idx, next_token), dim=1)
+        log_probs.append(log_prob)
+    return idx, log_probs
+
+
+def train(args: argparse.Namespace) -> None:
+    data = load_dataset(args.dataset)
+    model = load_model(args.model_path)
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    step = 0
+    for epoch in range(args.epochs):
+        for sample in data:
+            prompt = sample.get("prompt") or sample.get("question") or ""
+            target = sample.get("solution") or sample.get("answer") or ""
+
+            idx = tokenizer.encode(prompt).long()
+            idx, log_probs = sample_with_grad(model, idx, args.max_new_tokens, args.temperature)
+            generated = tokenizer.decode(idx[:, -args.max_new_tokens:])
+
+            acc_r = accuracy_reward(generated, target)
+            tag_r = reasoning_tag_reward(generated)
+            len_r = length_reward(generated, args.max_new_tokens)
+            reward = acc_r + tag_r + len_r
+
+            loss = -reward * torch.stack(log_probs).sum()
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
+            step += 1
+            logger.info(
+                "step=%d epoch=%d loss=%.4f reward=%.4f acc=%.2f tags=%.2f len=%.2f",
+                step,
+                epoch,
+                loss.item(),
+                reward,
+                acc_r,
+                tag_r,
+                len_r,
+            )
+
+            if step % args.save_every == 0:
+                ckpt = Path(args.logdir) / f"checkpoint_{step}.pt"
+                torch.save(model.state_dict(), ckpt)
+                logger.info("Saved checkpoint to %s", ckpt)
+
+    final_ckpt = Path(args.logdir) / "final.pt"
+    torch.save(model.state_dict(), final_ckpt)
+    logger.info("Training complete. Final model saved to %s", final_ckpt)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="GRPO training for Arianna-C")
+    parser.add_argument("--dataset", required=True, help="Path to JSONL dataset")
+    parser.add_argument("--model-path", help="Optional path to model checkpoint")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--save-every", type=int, default=100)
+    parser.add_argument(
+        "--logdir",
+        default=str(DEFAULT_LOGDIR),
+        help="Directory for logs and checkpoints",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    train(parse_args())


### PR DESCRIPTION
## Summary
- implement `finetuning/grpo_train.py` to fine-tune Arianna-C via GRPO with accuracy, reasoning-tag and length rewards
- log rewards/losses and write checkpoints under `logs/grpo/`
- document GRPO training usage in the README

## Testing
- `flake8 finetuning/grpo_train.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688edb6024f08329bf06606fa6aa5db0