### PR TITLE
feat: add embedding search

### DIFF
--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,5 +1,4 @@
 import os
-
 import numpy as np
 
 from arianna_chain import SelfMonitor
@@ -51,6 +50,30 @@ def test_embedding_search(tmp_path):
         monitor.log("cat", "meow")
         monitor.log("dog", "bark")
         results = monitor.search_embedding("feline", limit=1)
+        assert results and results[0][0] == "cat"
+    finally:
+        os.chdir(cwd)
+
+
+def test_search_combined(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        monitor = SelfMonitor(db_path=str(tmp_path / "mem.sqlite"))
+
+        class DummyEmbed:
+            def encode(self, texts):
+                mapping = {
+                    "cat": np.array([1.0, 0.0], dtype=np.float32),
+                    "dog": np.array([0.0, 1.0], dtype=np.float32),
+                    "feline": np.array([1.0, 0.0], dtype=np.float32),
+                }
+                return np.stack([mapping.get(t, np.zeros(2, dtype=np.float32)) for t in texts])
+
+        monitor.embed_model = DummyEmbed()
+        monitor.log("cat", "meow")
+        monitor.log("dog", "bark")
+        results = monitor.search("feline", limit=1)
         assert results and results[0][0] == "cat"
     finally:
         os.chdir(cwd)


### PR DESCRIPTION
## Summary
- add optional MiniLM embeddings to SelfMonitor with env toggle
- save embeddings for code snapshots and logs
- combine FTS and cosine similarity for richer searches
- cover combined search with new test

## Testing
- `flake8 arianna_chain.py tests/test_monitor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688edb96249883298d2f1ab495a2929f