### PR TITLE
Add reasoning metrics to complexity estimator

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,9 @@ line_length = 119
 [flake8]
 max-line-length = 119
 extend-ignore = E203
+
+[complexity_weights]
+entropy = 1.0
+steps = 1.0
+depth = 1.0
+uniqueness = 1.0

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,14 +3,20 @@ from arianna_chain import ThoughtComplexityLogger, estimate_complexity_and_entro
 
 def test_estimate_complexity_and_entropy_keywords():
     msg = "This is a paradox that asks why it is recursive"
-    tokens, entropy, _ = estimate_complexity_and_entropy(msg)
+    tokens, entropy, _, steps, depth, uniq = estimate_complexity_and_entropy(msg)
     assert tokens == len(tokenizer.encode(msg))
     assert 0 <= entropy <= 1
+    assert steps == 0
+    assert depth == 0
+    assert 0 <= uniq <= 1
 
 
 def test_logger_records_and_recent():
     logger = ThoughtComplexityLogger(log_file="logs/test_log.jsonl")
-    entry = logger.log_turn("test message", 2, 0.5)
+    entry = logger.log_turn("test message", 2, 0.5, None, steps=1, depth=2, uniqueness=0.5)
     assert entry.tokens == 2
     assert entry.perplexity is None
+    assert entry.steps == 1
+    assert entry.depth == 2
+    assert entry.uniqueness == 0.5
     assert logger.recent(1)[0].message == "test message"

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -100,7 +100,7 @@ def test_tree_reason_loop_selects_best_branch() -> None:
         patch("arianna_chain.reason_loop", side_effect=["bad", "good"]) as mock_loop,
         patch(
             "arianna_chain.estimate_complexity_and_entropy",
-            side_effect=lambda ans: (1, {"bad": 0.1, "good": 0.9}[ans]),
+            side_effect=lambda ans: (1, {"bad": 0.1, "good": 0.9}[ans], None, 0, 0, 1.0),
         ),
     ):
         result = tree_reason_loop("Q", beam_size=2, depth=1)

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -21,7 +21,15 @@ def _patch_env():
         patch("arianna_chain.quantize_2bit"),
         patch(
             "arianna_chain.thought_logger.log_turn",
-            return_value=SimpleNamespace(tokens=1, entropy=0.1, perplexity=None, timestamp="t"),
+            return_value=SimpleNamespace(
+                tokens=1,
+                entropy=0.1,
+                perplexity=None,
+                steps=0,
+                depth=0,
+                uniqueness=1.0,
+                timestamp="t",
+            ),
         ),
     )
 


### PR DESCRIPTION
## Summary
- track `<think>` tag counts, list depth, and token uniqueness in `estimate_complexity_and_entropy`
- expose metric weights via `setup.cfg`/ENV and log them through `ThoughtLogEntry`
- extend tests to cover new reasoning metrics

## Testing
- `flake8 arianna_chain.py tests/test_logger.py tests/test_reasoning.py tests/test_reflection.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688edb9eec3c8329964d251715f30439