### PR TITLE
refactor tools into modular registry

### DIFF
--- a/tools/date_parse.py
+++ b/tools/date_parse.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Dict, Any
+
+
+def date_parse(text: str) -> str:
+    text = text.strip()
+    fmts = ["%Y-%m-%d", "%d.%m.%Y", "%d/%m/%Y", "%d-%m-%Y", "%Y/%m/%d"]
+    for f in fmts:
+        try:
+            dt = datetime.strptime(text, f)
+            return dt.date().isoformat()
+        except Exception:
+            continue
+    try:
+        return datetime.fromisoformat(text).date().isoformat()
+    except Exception:
+        return json.dumps({"ok": False, "error": "unrecognized date"})
+
+
+TOOL_SPEC: Dict[str, Any] = {
+    "name": "date.parse",
+    "desc": "parse common date formats to ISO date.",
+    "args": {"text": "string"},
+    "func": date_parse,
+}

--- a/tools/math_eval.py
+++ b/tools/math_eval.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import ast
+import operator as op
+from typing import Dict, Any
+
+
+def math_eval(expr: str) -> str:
+    allowed = {
+        ast.Add: op.add,
+        ast.Sub: op.sub,
+        ast.Mult: op.mul,
+        ast.Div: op.truediv,
+        ast.Pow: op.pow,
+        ast.USub: op.neg,
+        ast.Mod: op.mod,
+        ast.FloorDiv: op.floordiv,
+    }
+
+    def eval_(node):
+        if isinstance(node, ast.Num):
+            return node.n
+        if isinstance(node, ast.UnaryOp) and type(node.op) in allowed:
+            return allowed[type(node.op)](eval_(node.operand))
+        if isinstance(node, ast.BinOp) and type(node.op) in allowed:
+            return allowed[type(node.op)](eval_(node.left), eval_(node.right))
+        raise ValueError("unsupported expression")
+
+    if "**" in expr and "e" in expr.lower():
+        raise ValueError("disallowed form")
+
+    node = ast.parse(expr, mode="eval").body
+    result = eval_(node)
+    if isinstance(result, (int, float)) and abs(result) > 1e12:
+        raise ValueError("result too large")
+    return str(result)
+
+
+TOOL_SPEC: Dict[str, Any] = {
+    "name": "math.eval",
+    "desc": "evaluate a safe arithmetic expression.",
+    "args": {"expr": "string"},
+    "func": math_eval,
+}

--- a/tools/memory_note.py
+++ b/tools/memory_note.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+def memory_note(text: str) -> str:
+    from arianna_chain import SelfMonitor, _redact
+
+    sm = SelfMonitor()
+    sm.note(_redact(text)[:1000])
+    return "ok"
+
+
+TOOL_SPEC: Dict[str, Any] = {
+    "name": "memory.note",
+    "desc": "store a short note to memory.",
+    "args": {"text": "string"},
+    "func": memory_note,
+}

--- a/tools/memory_search.py
+++ b/tools/memory_search.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+def memory_search(query: str, limit: int = 3) -> str:
+    from arianna_chain import SelfMonitor, _redact
+
+    sm = SelfMonitor()
+    hits = sm.search_prompts_and_notes(query, limit=limit)
+    if not hits:
+        return "(no hits)"
+    out = [f"- {_redact(h)}" for h in hits]
+    return "\n".join(out)
+
+
+TOOL_SPEC: Dict[str, Any] = {
+    "name": "memory.search",
+    "desc": "search previous prompts/answers/notes (redacted).",
+    "args": {"query": "string", "limit": "int"},
+    "func": memory_search,
+}

--- a/tools/text_regex_extract.py
+++ b/tools/text_regex_extract.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Dict, Any
+
+
+def text_regex_extract(pattern: str, text: str, limit: int = 10, flags: str = "") -> str:
+    fl = 0
+    if "i" in flags:
+        fl |= re.IGNORECASE
+    if "m" in flags:
+        fl |= re.MULTILINE
+    if "s" in flags:
+        fl |= re.DOTALL
+    try:
+        rgx = re.compile(pattern, fl)
+        matches = rgx.findall(text)
+        if isinstance(matches, list):
+            matches = matches[: max(1, min(limit, 50))]
+            flat = []
+            for m in matches:
+                if isinstance(m, tuple):
+                    flat.append("".join(map(str, m)))
+                else:
+                    flat.append(str(m))
+            uniq, seen = [], set()
+            for x in flat:
+                if x not in seen:
+                    seen.add(x)
+                    uniq.append(x)
+            return json.dumps(uniq, ensure_ascii=False)
+        return "[]"
+    except Exception as e:
+        return json.dumps({"ok": False, "error": str(e)})
+
+
+TOOL_SPEC: Dict[str, Any] = {
+    "name": "text.regex_extract",
+    "desc": "regex matches as JSON list.",
+    "args": {"pattern": "string", "text": "string", "limit": "int", "flags": "string"},
+    "func": text_regex_extract,
+}

--- a/tools/time_now.py
+++ b/tools/time_now.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Any
+
+
+def time_now() -> str:
+    return datetime.utcnow().isoformat() + "Z"
+
+
+TOOL_SPEC: Dict[str, Any] = {
+    "name": "time.now",
+    "desc": "UTC timestamp now.",
+    "args": {},
+    "func": time_now,
+}


### PR DESCRIPTION
## Summary
- move tool implementations to separate modules inside `tools/` each exporting `TOOL_SPEC`
- dynamically load available tools at startup and build manifest in `arianna_chain`

## Testing
- `flake8 arianna_chain.py tools`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ee06c29a083298a446d5e2c7a3d23