### PR TITLE
Add confidence logging and distillation dataset

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -10,7 +10,7 @@ def test_estimate_complexity_and_entropy_keywords():
 
 def test_logger_records_and_recent():
     logger = ThoughtComplexityLogger(log_file="logs/test_log.jsonl")
-    entry = logger.log_turn("test message", 2, 0.5)
+    entry = logger.log_turn("test message", 2, 0.5, confidence=0.8)
     assert entry.tokens == 2
     assert entry.perplexity is None
     assert logger.recent(1)[0].message == "test message"

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -21,7 +21,7 @@ def _patch_env():
         patch("arianna_chain.quantize_2bit"),
         patch(
             "arianna_chain.thought_logger.log_turn",
-            return_value=SimpleNamespace(tokens=1, entropy=0.1, perplexity=None, timestamp="t"),
+            return_value=SimpleNamespace(tokens=1, entropy=0.1, perplexity=None, timestamp="t", confidence=0.5),
         ),
     )
 


### PR DESCRIPTION
## Summary
- log confidence in ThoughtComplexityLogger entries and distill prompt/plan/answer pairs
- extend GRPO training script to read confidence-aware datasets and filter low confidence samples
- add tests for the new logging format and data

## Testing
- `flake8 arianna_chain.py finetuning/grpo_train.py tests/test_logger.py tests/test_reasoning.py tests/test_reflection.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee098497883299a8db32dd86b3526