### PR TITLE
Handle plan/reasoning SSE events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Inspired by Andrej Karpathy's [nanoGPT](https://github.com/karpathy/nanoGPT), th
 python arianna_chain.py "2+2="
 ```
 
+## Streaming SSE events
+
+The server sends Server-Sent Events while generating a reply:
+
+- `plan.delta` – incremental planning text
+- `reasoning.delta` – reasoning trace fragments
+- `repair.delta` – self-repair fragments
+- `response.output_text.delta` – answer text chunks
+- `response.completed` – final result object
+- `ping` – keep-alive heartbeat
+- `response.error` – error details
+
 ## Reasoning Logger
 
 The engine now keeps a running account of its own cognitive load. Each response is examined through a heuristic lens that gauges how tangled the thought felt and how varied the vocabulary spread itself across the page. This record grows quietly in the background and may be summoned when reflection is desired.

--- a/arianna_chain.py
+++ b/arianna_chain.py
@@ -577,8 +577,11 @@ def call_liquid(prompt: str, *, temperature: Optional[float] = None, top_p: Opti
 
 def call_liquid_stream(prompt: str, *, temperature: Optional[float] = None, top_p: Optional[float] = None, timeout: float = 60.0) -> Iterable[Tuple[str, Dict[str, Any] | None]]:
     """
-    Возвращает пары (event_type, data_dict). Событие и data «склеены»:
+    Возвращает пары (event_type, data_dict). Возможные типы:
       - ("response.output_text.delta", {"delta": "..."})
+      - ("plan.delta", {"delta": "..."})
+      - ("reasoning.delta", {"delta": "..."})
+      - ("repair.delta", {"delta": "..."})
       - ("response.completed", {...})
       - ("ping", {})
       - ("response.error", {"error": "..."})


### PR DESCRIPTION
## Summary
- stream `plan.delta`, `reasoning.delta`, and `repair.delta` events from the server
- expose new SSE types through `call_liquid_stream`
- document all SSE event types in the README

## Testing
- `python -m py_compile server.py arianna_chain.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ee0a7925483299381d65b0493f332