### PR TITLE
Add MoE adapter with configurable expert routing

### DIFF
--- a/models/moe_adapter.py
+++ b/models/moe_adapter.py
@@ -1,0 +1,76 @@
+import math
+import torch
+import torch.nn as nn
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        assert config.n_embd % config.n_head == 0
+        self.key = nn.Linear(config.n_embd, config.n_embd, bias=False)
+        self.query = nn.Linear(config.n_embd, config.n_embd, bias=False)
+        self.value = nn.Linear(config.n_embd, config.n_embd, bias=False)
+        self.proj = nn.Linear(config.n_embd, config.n_embd)
+        self.attn_dropout = nn.Dropout(config.dropout)
+        self.resid_dropout = nn.Dropout(config.dropout)
+        self.n_head = config.n_head
+        self.head_dim = config.n_embd // config.n_head
+        self.register_buffer(
+            "bias",
+            torch.tril(torch.ones(config.block_size, config.block_size)).view(
+                1, 1, config.block_size, config.block_size
+            ),
+            persistent=False,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, T, C = x.size()
+        k = self.key(x).view(B, T, self.n_head, self.head_dim).transpose(1, 2)
+        q = self.query(x).view(B, T, self.n_head, self.head_dim).transpose(1, 2)
+        v = self.value(x).view(B, T, self.n_head, self.head_dim).transpose(1, 2)
+        att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(self.head_dim))
+        att = att.masked_fill(self.bias[:, :, :T, :T] == 0, float("-inf"))
+        att = torch.softmax(att, dim=-1)
+        att = self.attn_dropout(att)
+        y = att @ v
+        y = y.transpose(1, 2).contiguous().view(B, T, C)
+        y = self.resid_dropout(self.proj(y))
+        return y
+
+
+class Expert(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.fc = nn.Linear(config.n_embd, 4 * config.n_embd)
+        self.proj = nn.Linear(4 * config.n_embd, config.n_embd)
+        self.dropout = nn.Dropout(config.dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.nn.functional.gelu(self.fc(x))
+        x = self.proj(x)
+        return self.dropout(x)
+
+
+class MoEBlock(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.ln1 = nn.LayerNorm(config.n_embd)
+        self.attn = CausalSelfAttention(config)
+        self.ln2 = nn.LayerNorm(config.n_embd)
+        self.experts = nn.ModuleList([Expert(config) for _ in range(config.n_experts)])
+        self.gate = nn.Linear(config.n_embd, config.n_experts)
+        self.top_k = max(1, min(config.active_experts, config.n_experts))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.ln1(x))
+        h = self.ln2(x)
+        gate_scores = torch.softmax(self.gate(h), dim=-1)
+        topk_scores, topk_indices = gate_scores.topk(self.top_k, dim=-1)
+        expert_outputs = torch.stack([expert(h) for expert in self.experts], dim=-1)
+        index = topk_indices.unsqueeze(2).expand(-1, -1, expert_outputs.size(2), -1)
+        topk_outputs = expert_outputs.gather(-1, index)
+        moe_out = (topk_outputs * topk_scores.unsqueeze(2)).sum(dim=-1)
+        return x + moe_out
+
+
+__all__ = ["MoEBlock"]


### PR DESCRIPTION
## Summary
- introduce `models.moe_adapter.MoEBlock` for gated top-k expert routing
- use `MoEBlock` in AriannaC transformer and expose expert counts in config
- add `--experts` CLI flag to control active experts

## Testing
- `flake8 arianna_chain.py models`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ee4b4692083298fa51683b87630dd