### PR TITLE
Add HTTP client validation and tests for malformed responses

### DIFF
--- a/arianna/__init__.py
+++ b/arianna/__init__.py
@@ -1,0 +1,3 @@
+from .http_client import HTTPClient
+
+__all__ = ["HTTPClient"]

--- a/arianna/http_client.py
+++ b/arianna/http_client.py
@@ -1,0 +1,93 @@
+import json
+import logging
+import threading
+from typing import Any, Dict, Tuple, Generator
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_FIELDS: Dict[str, Tuple[type, ...]] = {
+    "mode": (str,),
+    "think": (str,),
+    "answer": (str,),
+    "stop": (bool,),
+    "step": (int,),
+    "confidence": (int, float),
+    "halt_reason": (str,),
+}
+
+
+class HTTPClient:
+    """Minimal HTTP client with basic validation."""
+
+    def __init__(self, timeout: float = 60.0):
+        self._local = threading.local()
+        self.timeout = timeout
+
+    # Internal -----------------------------------------------------------------
+    def _sess(self) -> requests.Session:
+        s = getattr(self._local, "sess", None)
+        if s is None:
+            s = requests.Session()
+            s.headers.update({"Content-Type": "application/json"})
+            self._local.sess = s
+        return s
+
+    # Requests -----------------------------------------------------------------
+    def post_json(self, url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(url, str):
+            raise TypeError(f"url must be str, got {type(url).__name__}")
+        if not isinstance(payload, dict):
+            raise TypeError("payload must be a dict")
+
+        r = self._sess().post(url, json=payload, timeout=self.timeout)
+        r.raise_for_status()
+        try:
+            data = r.json()
+        except ValueError as e:  # pragma: no cover - network errors
+            raise ValueError("Response is not valid JSON") from e
+        if not isinstance(data, dict):
+            raise ValueError(f"Response JSON must be object, got {type(data).__name__}")
+
+        missing = [k for k in REQUIRED_FIELDS if k not in data]
+        if missing:
+            raise ValueError(f"Missing fields in response: {', '.join(missing)}")
+        wrong = [k for k, t in REQUIRED_FIELDS.items() if not isinstance(data.get(k), t)]
+        if wrong:
+            raise ValueError(f"Invalid field types in response: {', '.join(wrong)}")
+        return data
+
+    # Streaming ----------------------------------------------------------------
+    def stream_sse(
+        self, url: str, payload: Dict[str, Any]
+    ) -> Generator[Tuple[str, Dict[str, Any] | None], None, None]:
+        if not isinstance(url, str):
+            raise TypeError("url must be str")
+        if not isinstance(payload, dict):
+            raise TypeError("payload must be a dict")
+
+        r = self._sess().post(url, json=payload, timeout=self.timeout, stream=True)
+        r.raise_for_status()
+        current_event = "message"
+        for line in r.iter_lines(decode_unicode=True):
+            if not line:
+                continue
+            if line.startswith("event:"):
+                event_name = line.split("event:", 1)[1].strip()
+                if event_name:
+                    current_event = event_name
+                else:
+                    logger.warning("Malformed event line: %s", line)
+                continue
+            if line.startswith("data:"):
+                data_raw = line.split("data:", 1)[1].strip()
+                try:
+                    data = json.loads(data_raw)
+                except Exception:
+                    logger.warning("Malformed JSON line: %s", line)
+                    yield (current_event, None)
+                    continue
+                yield (current_event, data)
+            else:
+                logger.warning("Unrecognized line: %s", line)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,63 @@
+import logging
+from typing import Any, Dict
+
+import pytest
+
+from arianna.http_client import HTTPClient
+
+
+class DummyResponse:
+    def __init__(self, data: Any, *, lines: list[str] | None = None):
+        self._data = data
+        self.status_code = 200
+        self._lines = lines or []
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self._data
+
+    def iter_lines(self, decode_unicode: bool = True):
+        for line in self._lines:
+            yield line
+
+
+class DummySession:
+    def __init__(self, resp: DummyResponse):
+        self.resp = resp
+
+    def post(self, url: str, json: Dict[str, Any], timeout: float, stream: bool = False):
+        return self.resp
+
+
+@pytest.fixture
+def client(monkeypatch):
+    c = HTTPClient()
+    # prevent real HTTP session creation
+    monkeypatch.setattr(c, "_sess", lambda: DummySession(DummyResponse({})))
+    return c
+
+
+def test_post_json_missing_fields(client, monkeypatch):
+    data = {"mode": "final"}  # missing required fields
+    resp = DummyResponse(data)
+    monkeypatch.setattr(client, "_sess", lambda: DummySession(resp))
+    with pytest.raises(ValueError) as exc:
+        client.post_json("http://example.com", {})
+    assert "Missing fields" in str(exc.value)
+
+
+def test_stream_sse_invalid_event_and_json(monkeypatch, caplog):
+    lines = [
+        "event:",  # invalid event
+        "data: {\"a\": 1",  # truncated JSON
+    ]
+    resp = DummyResponse({}, lines=lines)
+    c = HTTPClient()
+    monkeypatch.setattr(c, "_sess", lambda: DummySession(resp))
+    with caplog.at_level(logging.WARNING):
+        items = list(c.stream_sse("http://example.com", {}))
+    assert items == [("message", None)]
+    assert any("Malformed event" in m for m in caplog.messages)
+    assert any("Malformed JSON" in m for m in caplog.messages)


### PR DESCRIPTION
## Summary
- add new `HTTPClient` with strict type and field checks
- log malformed SSE events and JSON while streaming
- cover malformed and truncated responses with tests

## Testing
- `flake8 arianna/http_client.py tests/test_http_client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899ff0587ac8329ba585e3396e5f0c7