### PR TITLE
Pin dependency versions and document update process

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ Notes on Modularity
 
 ⸻
 
+Dependency Management
+        •       requirements.txt pins tested versions for reproducible CPU-only installs.
+        •       PyTorch is pulled from the CPU wheel index (`--extra-index-url https://download.pytorch.org/whl/cpu`).
+        •       To upgrade, install the new package version, update requirements.txt, then run `flake8 && pytest`.
+
+⸻
+
 Acknowledgements
 	•	DeepSeek R1 concepts
 	•	nanoGPT by Andrej Karpathy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-torch
-tokenizers
-flask
-openai>=1.0.0
-gunicorn
-sentence-transformers
-faiss-cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
 
-python-telegram-bot
+torch==2.8.0+cpu
+tokenizers==0.21.4
+Flask==3.1.1
+openai==1.99.6
+gunicorn==23.0.0
+sentence-transformers==5.1.0
+faiss-cpu==1.11.0.post1
+python-telegram-bot==22.3


### PR DESCRIPTION
## Summary
- pin core dependencies to tested versions with CPU-only PyTorch
- document dependency management and upgrade steps in README

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899ff1ef20083299dd1571f86309511