### PR TITLE
Guard vector store operations with threading lock

### DIFF
--- a/arianna/__init__.py
+++ b/arianna/__init__.py
@@ -1,0 +1,4 @@
+# Core Arianna modules.
+from .vector_store import VectorStore
+
+__all__ = ["VectorStore"]

--- a/arianna/vector_store.py
+++ b/arianna/vector_store.py
@@ -1,0 +1,80 @@
+"""Simple in-memory vector store.
+
+The `add` and `search` methods are thread-safe, but they block other
+threads when FAISS is unavailable because the pure Python fallback holds
+the GIL. With FAISS installed, underlying operations release the GIL and
+remain non-blocking.
+"""
+
+from __future__ import annotations
+
+from typing import List
+import threading
+
+import numpy as np
+
+try:  # pragma: no cover
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover
+    faiss = None
+
+
+class VectorStore:
+    """Store documents as dense vectors and perform similarity search."""
+
+    def __init__(self, documents: List[str] | None = None, dim: int = 128) -> None:
+        self.dim = dim
+        self.documents: List[str] = []
+        self.lock = threading.Lock()
+        if faiss:
+            self.index = faiss.IndexFlatIP(dim)
+        else:  # pragma: no cover
+            self.index = None
+            self.vectors: List[np.ndarray] = []
+        if documents:
+            self.add(documents)
+
+    def _embed(self, text: str) -> np.ndarray:
+        vec = np.frombuffer(text.encode("utf-8"), dtype="uint8").astype("float32")
+        if vec.size < self.dim:
+            vec = np.pad(vec, (0, self.dim - vec.size))
+        else:
+            vec = vec[: self.dim]
+        norm = np.linalg.norm(vec) or 1.0
+        return vec / norm
+
+    def add(self, docs: List[str]) -> None:
+        """Add documents to the store.
+
+        Thread-safe; non-blocking only when FAISS is available.
+        """
+        embeddings = (
+            np.vstack([self._embed(d) for d in docs])
+            if docs
+            else np.empty((0, self.dim), dtype="float32")
+        )
+        with self.lock:
+            if self.index is not None and embeddings.size:
+                self.index.add(embeddings)
+            else:  # pragma: no cover
+                for emb in embeddings:
+                    self.vectors.append(emb)
+            self.documents.extend(docs)
+
+    def search(self, query: str, k: int = 3) -> List[str]:
+        """Return up to ``k`` most similar documents.
+
+        Thread-safe; non-blocking only when FAISS is available.
+        """
+        if not self.documents:
+            return []
+        qvec = self._embed(query).reshape(1, -1)
+        k = min(k, len(self.documents))
+        with self.lock:
+            if self.index is not None:
+                _, idxs = self.index.search(qvec, k)
+                ids = idxs[0]
+            else:  # pragma: no cover
+                sims = [float(np.dot(qvec.squeeze(), v)) for v in self.vectors]
+                ids = np.argsort(sims)[::-1][:k]
+        return [self.documents[i] for i in ids]

--- a/arianna_chain.py
+++ b/arianna_chain.py
@@ -37,6 +37,7 @@ import threading
 import requests
 import torch
 import torch.nn as nn
+from arianna.vector_store import VectorStore
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Core prompt (embedded persona)
@@ -262,57 +263,6 @@ def estimate_complexity_and_entropy(
 
 thought_logger = ThoughtComplexityLogger()
 
-# ────────────────────────────────────────────────────────────────────────────────
-# Simple vector store
-# ────────────────────────────────────────────────────────────────────────────────
-class VectorStore:
-    """Store documents as dense vectors and perform similarity search."""
-
-    def __init__(self, documents: List[str] | None = None, dim: int = 128) -> None:
-        self.dim = dim
-        self.documents: List[str] = []
-        if faiss:
-            self.index = faiss.IndexFlatIP(dim)
-        else:  # pragma: no cover
-            self.index = None
-            self.vectors: List[np.ndarray] = []
-        if documents:
-            self.add(documents)
-
-    def _embed(self, text: str) -> np.ndarray:
-        vec = np.frombuffer(text.encode("utf-8"), dtype="uint8").astype("float32")
-        if vec.size < self.dim:
-            vec = np.pad(vec, (0, self.dim - vec.size))
-        else:
-            vec = vec[: self.dim]
-        norm = np.linalg.norm(vec) or 1.0
-        return vec / norm
-
-    def add(self, docs: List[str]) -> None:
-        embeddings = (
-            np.vstack([self._embed(d) for d in docs])
-            if docs
-            else np.empty((0, self.dim), dtype="float32")
-        )
-        if self.index is not None and embeddings.size:
-            self.index.add(embeddings)
-        else:  # pragma: no cover
-            for emb in embeddings:
-                self.vectors.append(emb)
-        self.documents.extend(docs)
-
-    def search(self, query: str, k: int = 3) -> List[str]:
-        if not self.documents:
-            return []
-        qvec = self._embed(query).reshape(1, -1)
-        k = min(k, len(self.documents))
-        if self.index is not None:
-            _, idxs = self.index.search(qvec, k)
-            ids = idxs[0]
-        else:  # pragma: no cover
-            sims = [float(np.dot(qvec.squeeze(), v)) for v in self.vectors]
-            ids = np.argsort(sims)[::-1][:k]
-        return [self.documents[i] for i in ids]
 
 # ────────────────────────────────────────────────────────────────────────────────
 # TRUE 2-bit weights on CPU (W2A8): pack/unpack + Linear


### PR DESCRIPTION
## Summary
- Add new `arianna.vector_store` module with a thread-safe `VectorStore`
- Wrap `add` and `search` calls in a `threading.Lock`
- Document that `add` and `search` only avoid blocking when FAISS is available
- Import the new vector store in `arianna_chain` for compatibility

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899ffb8869883299a7b52308702405a