### PR TITLE
Validate Base64 in prompt sanitizer

### DIFF
--- a/tests/test_sanitize_prompt.py
+++ b/tests/test_sanitize_prompt.py
@@ -1,0 +1,14 @@
+import base64
+
+from server import _sanitize_prompt
+
+
+def test_sanitize_prompt_leaves_invalid_base64():
+    invalid = 'A' * 201  # length not multiple of 4
+    assert _sanitize_prompt(invalid) == invalid
+
+
+def test_sanitize_prompt_redacts_valid_base64():
+    payload = base64.b64encode(b'x' * 300).decode()
+    sanitized = _sanitize_prompt(payload)
+    assert sanitized == '[BASE64_REDACTED]'


### PR DESCRIPTION
## Summary
- Ensure prompt sanitizer checks Base64 strings by decoding and limits block analysis length
- Add tests covering invalid long strings and valid Base64 payloads

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a02b3c7e083298f8612b06ee6ed0c