### PR TITLE
Add context manager support for SelfMonitor

### DIFF
--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -9,11 +9,11 @@ def test_search_exact(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        monitor = SelfMonitor(db_path=str(tmp_path / "mem.sqlite"))
-        monitor.log("hello world", "out1")
-        monitor.log("another message", "out2")
-        results = monitor.search("hello world")
-        assert ("hello world", "out1") in results
+        with SelfMonitor(db_path=str(tmp_path / "mem.sqlite")) as monitor:
+            monitor.log("hello world", "out1")
+            monitor.log("another message", "out2")
+            results = monitor.search("hello world")
+            assert ("hello world", "out1") in results
     finally:
         os.chdir(cwd)
 
@@ -22,12 +22,12 @@ def test_search_tfidf_limit(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        monitor = SelfMonitor(db_path=str(tmp_path / "mem.sqlite"))
-        for i in range(3):
-            monitor.log(f"hello {i}", f"out{i}")
-        results = monitor.search("hello", limit=2)
-        assert len(results) == 2
-        assert all("hello" in p for p, _ in results)
+        with SelfMonitor(db_path=str(tmp_path / "mem.sqlite")) as monitor:
+            for i in range(3):
+                monitor.log(f"hello {i}", f"out{i}")
+            results = monitor.search("hello", limit=2)
+            assert len(results) == 2
+            assert all("hello" in p for p, _ in results)
     finally:
         os.chdir(cwd)
 
@@ -36,22 +36,21 @@ def test_embedding_search(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        monitor = SelfMonitor(db_path=str(tmp_path / "mem.sqlite"))
+        with SelfMonitor(db_path=str(tmp_path / "mem.sqlite")) as monitor:
+            class DummyEmbed:
+                def encode(self, texts):
+                    mapping = {
+                        "cat": np.array([1.0, 0.0], dtype=np.float32),
+                        "dog": np.array([0.0, 1.0], dtype=np.float32),
+                        "feline": np.array([1.0, 0.0], dtype=np.float32),
+                    }
+                    return np.stack([mapping.get(t, np.zeros(2, dtype=np.float32)) for t in texts])
 
-        class DummyEmbed:
-            def encode(self, texts):
-                mapping = {
-                    "cat": np.array([1.0, 0.0], dtype=np.float32),
-                    "dog": np.array([0.0, 1.0], dtype=np.float32),
-                    "feline": np.array([1.0, 0.0], dtype=np.float32),
-                }
-                return np.stack([mapping.get(t, np.zeros(2, dtype=np.float32)) for t in texts])
-
-        monitor.embed_model = DummyEmbed()
-        monitor.log("cat", "meow")
-        monitor.log("dog", "bark")
-        results = monitor.search_embedding("feline", limit=1)
-        assert results and results[0][0] == "cat"
+            monitor.embed_model = DummyEmbed()
+            monitor.log("cat", "meow")
+            monitor.log("dog", "bark")
+            results = monitor.search_embedding("feline", limit=1)
+            assert results and results[0][0] == "cat"
     finally:
         os.chdir(cwd)
 
@@ -60,22 +59,21 @@ def test_search_combined(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        monitor = SelfMonitor(db_path=str(tmp_path / "mem.sqlite"))
+        with SelfMonitor(db_path=str(tmp_path / "mem.sqlite")) as monitor:
+            class DummyEmbed:
+                def encode(self, texts):
+                    mapping = {
+                        "cat": np.array([1.0, 0.0], dtype=np.float32),
+                        "dog": np.array([0.0, 1.0], dtype=np.float32),
+                        "feline": np.array([1.0, 0.0], dtype=np.float32),
+                    }
+                    return np.stack([mapping.get(t, np.zeros(2, dtype=np.float32)) for t in texts])
 
-        class DummyEmbed:
-            def encode(self, texts):
-                mapping = {
-                    "cat": np.array([1.0, 0.0], dtype=np.float32),
-                    "dog": np.array([0.0, 1.0], dtype=np.float32),
-                    "feline": np.array([1.0, 0.0], dtype=np.float32),
-                }
-                return np.stack([mapping.get(t, np.zeros(2, dtype=np.float32)) for t in texts])
-
-        monitor.embed_model = DummyEmbed()
-        monitor.log("cat", "meow")
-        monitor.log("dog", "bark")
-        results = monitor.search("feline", limit=1)
-        assert results and results[0][0] == "cat"
+            monitor.embed_model = DummyEmbed()
+            monitor.log("cat", "meow")
+            monitor.log("dog", "bark")
+            results = monitor.search("feline", limit=1)
+            assert results and results[0][0] == "cat"
     finally:
         os.chdir(cwd)
 
@@ -84,22 +82,22 @@ def test_link_and_graph_search(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        monitor = SelfMonitor()
-        monitor.log("p1", "o1")
-        note_text = "note1"
-        monitor.note(note_text)
-        p_sha = hashlib.sha256("p1".encode()).hexdigest()
-        n_sha = hashlib.sha256(note_text.encode()).hexdigest()
-        monitor.link_prompt(p_sha, n_sha, "refers")
-        edges = monitor.graph_search(p_sha, depth=1)
-        assert (p_sha, n_sha, "refers") in edges
-        monitor.log("p2", "o2")
-        note2 = "note2"
-        monitor.note(note2)
-        p2_sha = hashlib.sha256("p2".encode()).hexdigest()
-        n2_sha = hashlib.sha256(note2.encode()).hexdigest()
-        TOOLS["memory.link"](prompt_sha=p2_sha, note_sha=n2_sha, relation="mentions")
-        edges2 = monitor.graph_search(p2_sha, depth=1)
-        assert (p2_sha, n2_sha, "mentions") in edges2
+        with SelfMonitor() as monitor:
+            monitor.log("p1", "o1")
+            note_text = "note1"
+            monitor.note(note_text)
+            p_sha = hashlib.sha256("p1".encode()).hexdigest()
+            n_sha = hashlib.sha256(note_text.encode()).hexdigest()
+            monitor.link_prompt(p_sha, n_sha, "refers")
+            edges = monitor.graph_search(p_sha, depth=1)
+            assert (p_sha, n_sha, "refers") in edges
+            monitor.log("p2", "o2")
+            note2 = "note2"
+            monitor.note(note2)
+            p2_sha = hashlib.sha256("p2".encode()).hexdigest()
+            n2_sha = hashlib.sha256(note2.encode()).hexdigest()
+            TOOLS["memory.link"](prompt_sha=p2_sha, note_sha=n2_sha, relation="mentions")
+            edges2 = monitor.graph_search(p2_sha, depth=1)
+            assert (p2_sha, n2_sha, "mentions") in edges2
     finally:
         os.chdir(cwd)

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -90,6 +90,7 @@ def test_reason_loop_alternates_and_logs() -> None:
         patch("arianna_chain.quantize_2bit", lambda _: None),
         patch("arianna_chain.SelfMonitor.__init__", return_value=None),
         patch("arianna_chain.SelfMonitor.log") as mock_log,
+        patch("arianna_chain.SelfMonitor.close"),
     ):
         result = reason_loop("Q", max_steps=1)
 
@@ -118,6 +119,7 @@ def test_reason_loop_writes_distill_log(tmp_path, monkeypatch) -> None:
         patch("arianna_chain.quantize_2bit", lambda _: None),
         patch("arianna_chain.SelfMonitor.__init__", return_value=None),
         patch("arianna_chain.SelfMonitor.log"),
+        patch("arianna_chain.SelfMonitor.close"),
         patch("arianna_chain.call_liquid", side_effect=RuntimeError),
     ):
         reason_loop("Q", max_steps=1)
@@ -141,6 +143,7 @@ def test_reason_loop_beam_selects_highest_scoring() -> None:
         patch("arianna_chain.call_liquid", side_effect=responses),
         patch("arianna_chain.SelfMonitor.__init__", return_value=None),
         patch("arianna_chain.SelfMonitor.log"),
+        patch("arianna_chain.SelfMonitor.close"),
     ):
         result = reason_loop("Q", max_steps=1, beams=2)
 
@@ -168,6 +171,7 @@ def test_reason_loop_verifies_after_act() -> None:
         patch("arianna_chain.verify_step", return_value="looks good") as mock_verify,
         patch("arianna_chain.SelfMonitor.__init__", return_value=None),
         patch("arianna_chain.SelfMonitor.log") as mock_log,
+        patch("arianna_chain.SelfMonitor.close"),
     ):
         reason_loop("Q", max_steps=2)
 
@@ -190,6 +194,7 @@ def test_reason_loop_uses_retrieval() -> None:
         patch("arianna_chain.call_liquid", side_effect=responses),
         patch("arianna_chain.SelfMonitor.__init__", return_value=None),
         patch("arianna_chain.SelfMonitor.log"),
+        patch("arianna_chain.SelfMonitor.close"),
     ):
         reason_loop("Q", max_steps=1, retrieve=True)
 
@@ -226,6 +231,7 @@ def test_multi_reason_majority_selection() -> None:
         patch("arianna_chain.reason_loop", side_effect=fake_reason) as mock_loop,
         patch("arianna_chain.SelfMonitor.__init__", return_value=None),
         patch("arianna_chain.SelfMonitor.log") as mock_log,
+        patch("arianna_chain.SelfMonitor.close"),
     ):
         result = multi_reason("Q", paths=4)
 

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -14,6 +14,12 @@ class DummyMonitor:
     def log(self, *_args, **_kwargs):
         pass
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
 
 def _patch_env():
     return (


### PR DESCRIPTION
## Summary
- ensure SelfMonitor can be used as a context manager with explicit `close()`
- switch memory tools, reason_loop, multi_reason, and generate_text to `with SelfMonitor()` usage
- update tests to accommodate the new context-managed monitor

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a024734c083299350f63a381d69d7