### PR TITLE
feat: allow external monitor

### DIFF
--- a/arianna_chain.py
+++ b/arianna_chain.py
@@ -1524,7 +1524,8 @@ def generate_text(
     max_new_tokens: int = 256,
     log_reasoning: bool = False,
     retrieve: bool = False,
-    ) -> str | tuple[str, dict[str, float | int]]:
+    monitor: SelfMonitor | None = None,
+) -> str | tuple[str, dict[str, float | int]]:
     prompt = (prompt or CORE_PROMPT).strip()
     if retrieve:
         try:
@@ -1616,8 +1617,10 @@ def generate_text(
         if log_reasoning:
             return text, {"tokens": rec.tokens, "entropy": rec.entropy, "perplexity": rec.perplexity, "timestamp": rec.timestamp}
         return text
-    with SelfMonitor() as sm:
-        return _run(sm)
+    if monitor is None:
+        with SelfMonitor() as sm:
+            return _run(sm)
+    return _run(monitor)
 
 def generate_with_think(
     prompt: Optional[str] = None,

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 
-from arianna_chain import generate_text
+from arianna_chain import SelfMonitor, generate_text
 from telegram import Update
 from telegram.ext import (
     ApplicationBuilder,
@@ -27,7 +27,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     """Send the user's message to Arianna-C and return the answer."""
     prompt = update.message.text or ""
     try:
-        result = await asyncio.to_thread(generate_text, prompt)
+        with SelfMonitor() as sm:
+            result = await asyncio.to_thread(generate_text, prompt, monitor=sm)
         text = result[0] if isinstance(result, tuple) else result
         match = re.search(r"<answer>(.*?)</answer>", text, re.DOTALL)
         reply = (match.group(1).strip() if match else text.strip()) or "(пустой ответ)"

--- a/tests/test_passed_monitor.py
+++ b/tests/test_passed_monitor.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from arianna_chain import SelfMonitor, generate_text, tokenizer
+
+
+def test_generate_text_uses_provided_monitor() -> None:
+    monitor = MagicMock(spec=SelfMonitor)
+    monitor.search_embedding.return_value = []
+    monitor.search.return_value = []
+    monitor.log.return_value = None
+    tokens = tokenizer.encode("result")
+    with (
+        patch("arianna_chain.AriannaC") as MockModel,
+        patch("arianna_chain.quantize_2bit", lambda _: None),
+        patch(
+            "arianna_chain.estimate_complexity_and_entropy", return_value=(1, 0.1, None)
+        ),
+        patch(
+            "arianna_chain.thought_logger.log_turn",
+            return_value=SimpleNamespace(tokens=1, entropy=0.1, perplexity=None, timestamp="t"),
+        ),
+        patch("arianna_chain.SelfMonitor") as MockSM,
+    ):
+        mock_model = MockModel.return_value
+        mock_model.generate.return_value = tokens
+        mock_model.eval.return_value = None
+        result = generate_text("prompt", use_liquid=False, monitor=monitor)
+    MockSM.assert_not_called()
+    monitor.log.assert_called_once_with("prompt", tokenizer.decode(tokens))
+    assert result == tokenizer.decode(tokens)

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -5,25 +5,12 @@ from arianna_chain import generate_text, tokenizer
 
 
 class DummyMonitor:
-    def __init__(self, *_, **__):
-        pass
-
-    def search_prompts(self, *_args, **_kwargs):
-        return []
-
     def log(self, *_args, **_kwargs):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
         pass
 
 
 def _patch_env():
     return (
-        patch("arianna_chain.SelfMonitor", DummyMonitor),
         patch("arianna_chain.quantize_2bit"),
         patch(
             "arianna_chain.thought_logger.log_turn",
@@ -35,35 +22,33 @@ def _patch_env():
 def test_reflection_revises_answer_when_critique_negative() -> None:
     draft = tokenizer.encode("draft")
     revised = tokenizer.encode("revised")
-    p1, p2, p3 = _patch_env()
+    p1, p2 = _patch_env()
     with (
         p1,
         p2,
-        p3,
         patch("arianna_chain.reflect", return_value="Needs work"),
         patch("arianna_chain.AriannaC") as MockModel,
     ):
         mock = MockModel.return_value
         mock.generate.side_effect = [draft, revised]
         mock.eval.return_value = None
-        result = generate_text("prompt", self_reflect=True)
+        result = generate_text("prompt", self_reflect=True, monitor=DummyMonitor())
     assert result == tokenizer.decode(revised)
     assert mock.generate.call_count == 2
 
 
 def test_reflection_keeps_answer_when_critique_positive() -> None:
     draft = tokenizer.encode("draft")
-    p1, p2, p3 = _patch_env()
+    p1, p2 = _patch_env()
     with (
         p1,
         p2,
-        p3,
         patch("arianna_chain.reflect", return_value="Looks good"),
         patch("arianna_chain.AriannaC") as MockModel,
     ):
         mock = MockModel.return_value
         mock.generate.return_value = draft
         mock.eval.return_value = None
-        result = generate_text("prompt", self_reflect=True)
+        result = generate_text("prompt", self_reflect=True, monitor=DummyMonitor())
     assert result == tokenizer.decode(draft)
     assert mock.generate.call_count == 1


### PR DESCRIPTION
## Summary
- allow generate_text to accept an optional SelfMonitor
- use provided monitor in main Telegram bot entry point
- add tests for custom monitor usage

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a067bafd4832992492f64d0a05b7f