### PR TITLE
feat: add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ write in light. When insight stirs, act.
 ⸻
 
 Endpoints
-	•	POST /generate — one-shot generation with optional log_reasoning
+	•	GET  /health       — service status and basic metrics
+	•	POST /generate     — one-shot generation with optional log_reasoning
 	•	GET  /generate_sse — streaming events (plan/reason/repair/output)
 
 Auth (optional): Authorization: Bearer <ARIANNA_SERVER_TOKEN>

--- a/server.py
+++ b/server.py
@@ -607,13 +607,21 @@ def _log(level: int, msg: Dict[str, Any]):
 # ────────────────────────────────────────────────────────────────────────────────
 @app.get("/health")
 def health():
+    openai_ok = False
+    try:
+        _openai_client().models.list()
+        openai_ok = True
+    except Exception:
+        openai_ok = False
+
     return jsonify({
-        "ok": True,
+        "status": "ok",
         "model": MODEL_DEFAULT,
         "model_light": MODEL_LIGHT,
         "model_heavy": MODEL_HEAVY,
         "cache_items": len(cache),
-        "schema_version": SCHEMA_VERSION
+        "openai": openai_ok,
+        "schema_version": SCHEMA_VERSION,
     }), 200
 
 # ────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add `/health` endpoint with status and connection metrics
- document `/health` in README

## Testing
- `flake8 server.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a2920bf6c8329acf346fd64e2085a