### PR TITLE
feat: add JSON logger with secret redaction

### DIFF
--- a/arianna_chain.py
+++ b/arianna_chain.py
@@ -26,6 +26,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from arianna_core.config import settings
 
+from logging_utils import get_logger, _SECRET_PATTERNS
+
 import numpy as np
 try:
     import faiss  # type: ignore
@@ -33,6 +35,8 @@ except Exception:  # pragma: no cover
     faiss = None
 import torch
 import torch.nn as nn
+
+logger = get_logger(__name__)
 
 from arianna_core import (
     AriannaC,
@@ -107,11 +111,6 @@ class VectorStore:
 # ────────────────────────────────────────────────────────────────────────────────
 # Tools (safe & redacted) + manifest
 # ────────────────────────────────────────────────────────────────────────────────
-_SECRET_PATTERNS = [
-    re.compile(r"sk-[A-Za-z0-9]{20,}"),
-    re.compile(r"(?i)(api[_-]?key|token)[\"'\s:]*[A-Za-z0-9\-_]{16,}"),
-    re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}"),  # JWT-ish
-]
 
 def _redact(text: str) -> str:
     red = text

--- a/finetuning/grpo_train.py
+++ b/finetuning/grpo_train.py
@@ -15,20 +15,17 @@ from typing import Dict, Iterator, List, Tuple
 import torch
 
 from arianna_chain import AriannaC, AriannaCConfig, tokenizer
+from logging_utils import get_logger
 
 
 DEFAULT_LOGDIR = Path("logs/grpo")
 DEFAULT_LOGDIR.mkdir(parents=True, exist_ok=True)
 
-logger = logging.getLogger("grpo")
-logger.setLevel(logging.INFO)
-formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+logger = get_logger("grpo")
 _file_handler = logging.FileHandler(DEFAULT_LOGDIR / "train.log")
-_file_handler.setFormatter(formatter)
-_stream_handler = logging.StreamHandler()
-_stream_handler.setFormatter(formatter)
+_file_handler.setFormatter(logger.handlers[0].formatter)
+_file_handler.addFilter(logger.handlers[0].filters[0])
 logger.addHandler(_file_handler)
-logger.addHandler(_stream_handler)
 
 
 def iter_dataset(path: str, min_confidence: float = 0.0) -> Iterator[Dict[str, str]]:

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,0 +1,57 @@
+import json
+import logging
+import re
+from datetime import datetime
+from typing import Any
+
+_SECRET_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),
+    re.compile(r"(?i)(api[_-]?key|token)[\"'\s:]*[A-Za-z0-9\-_]{16,}"),
+    re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\\.[A-Za-z0-9_\-]{10,}\\.[A-Za-z0-9_\-]{10,}"),
+]
+
+
+def _redact(text: str) -> str:
+    red = text
+    for pat in _SECRET_PATTERNS:
+        red = pat.sub("[REDACTED]", red)
+    return red
+
+
+class SecretFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        if isinstance(record.msg, str):
+            record.msg = _redact(record.msg)
+        if record.args:
+            record.args = tuple(_redact(str(a)) for a in record.args)
+        return True
+
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        message = record.getMessage()
+        log: dict[str, Any] = {
+            "ts": datetime.utcnow().isoformat(),
+            "lvl": record.levelname,
+            "msg": message,
+        }
+        trace_id = getattr(record, "trace_id", None)
+        if trace_id is not None:
+            log["trace_id"] = trace_id
+        return json.dumps(log, ensure_ascii=False)
+
+
+def get_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    handler = logging.StreamHandler()
+    handler.addFilter(SecretFilter())
+    handler.setFormatter(JSONFormatter())
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    return logger
+
+
+__all__ = ["get_logger", "_SECRET_PATTERNS", "SecretFilter", "JSONFormatter"]

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,12 @@
+import json
+from logging_utils import get_logger
+
+
+def test_secret_redaction(capfd):
+    logger = get_logger("test_redaction")
+    secret = "sk-1234567890ABCDEFGHIJKLMNOP"
+    logger.info("token=%s", secret)
+    err = capfd.readouterr().err.strip()
+    data = json.loads(err)
+    assert secret not in data["msg"]
+    assert "[REDACTED]" in data["msg"]


### PR DESCRIPTION
## Summary
- add `logging_utils.get_logger` with JSON formatting and secret redaction
- use central logger in `server`, `arianna_chain`, and GRPO training script
- test that logger redacts sensitive tokens

## Testing
- `flake8 logging_utils.py arianna_chain.py server.py finetuning/grpo_train.py tests/test_logging_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a36dd07bc832987737732e36a5da5