### PR TITLE
feat: use sentence transformer in vector store

### DIFF
--- a/tests/test_rewards_vectorstore.py
+++ b/tests/test_rewards_vectorstore.py
@@ -1,7 +1,28 @@
 from __future__ import annotations
 
+import sys
+import types
+
+import numpy as np
+import pytest
+
 from arianna_chain import VectorStore
 from arianna_core import format_reward, reasoning_steps_reward
+
+
+def _patch_sentence_transformer(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummySentenceTransformer:
+        def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            self._dim = 2
+
+        def encode(self, texts: list[str]) -> np.ndarray:  # type: ignore[no-untyped-def]
+            return np.zeros((len(texts), 2), dtype=np.float32)
+
+        def get_sentence_embedding_dimension(self) -> int:  # type: ignore[no-untyped-def]
+            return self._dim
+
+    module = types.SimpleNamespace(SentenceTransformer=DummySentenceTransformer)
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
 
 
 def test_format_reward_valid_and_invalid() -> None:
@@ -18,7 +39,8 @@ def test_reasoning_steps_reward() -> None:
     assert reasoning_steps_reward(text_bad) == 0.0
 
 
-def test_vector_store_search() -> None:
+def test_vector_store_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_sentence_transformer(monkeypatch)
     store = VectorStore()
     store.add(["hello world", "foo bar", "baz"])
     results = store.search("foo")

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,44 +1,55 @@
+import sys
+import types
+
 import numpy as np
 import pytest
+
 import arianna_chain
 from arianna_chain import VectorStore
 
 
-def _embed(text: str, dim: int) -> np.ndarray:
-    vec = np.frombuffer(text.encode("utf-8"), dtype="uint8").astype("float32")
-    if vec.size < dim:
-        vec = np.pad(vec, (0, dim - vec.size))
-    else:
-        vec = vec[: dim]
-    norm = np.linalg.norm(vec) or 1.0
-    return vec / norm
+def _patch_sentence_transformer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a lightweight stand‑in for SentenceTransformer."""
+
+    class DummySentenceTransformer:
+        def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            self._dim = 2
+
+        def encode(self, texts: list[str]) -> np.ndarray:  # type: ignore[no-untyped-def]
+            out: list[np.ndarray] = []
+            for t in texts:
+                tl = t.lower()
+                if "cat" in tl or "feline" in tl:
+                    out.append(np.array([1.0, 0.0], dtype=np.float32))
+                elif "dog" in tl or "canine" in tl:
+                    out.append(np.array([0.0, 1.0], dtype=np.float32))
+                else:
+                    out.append(np.zeros(2, dtype=np.float32))
+            return np.stack(out)
+
+        def get_sentence_embedding_dimension(self) -> int:  # type: ignore[no-untyped-def]
+            return self._dim
+
+    module = types.SimpleNamespace(SentenceTransformer=DummySentenceTransformer)
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
 
 
-def _expected_order(docs: list[str], query: str, dim: int) -> list[str]:
-    qvec = _embed(query, dim)
-    sims = [float(np.dot(qvec, _embed(d, dim))) for d in docs]
-    ids = np.argsort(sims)[::-1]
-    return [docs[i] for i in ids]
-
-
-def test_search_with_faiss() -> None:
+def test_search_with_faiss(monkeypatch: pytest.MonkeyPatch) -> None:
     if arianna_chain.faiss is None:
         pytest.skip("faiss not installed")
-    docs = ["foo", "bar", "baz"]
-    query = "foo"
-    dim = 16
-    store = VectorStore(docs, dim=dim)
-    expected = _expected_order(docs, query, dim)
-    results = store.search(query, k=len(docs))
-    assert results == expected
+    _patch_sentence_transformer(monkeypatch)
+    docs = ["a small cat", "a friendly dog"]
+    store = VectorStore(docs)
+    results = store.search("feline", k=len(docs))
+    assert results[0] == docs[0]
+    assert store.dim == 2
 
 
 def test_search_without_faiss(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(arianna_chain, "faiss", None)
-    docs = ["foo", "bar", "baz"]
-    query = "foo"
-    dim = 16
-    store = VectorStore(docs, dim=dim)
-    expected = _expected_order(docs, query, dim)
-    results = store.search(query, k=len(docs))
-    assert results == expected
+    _patch_sentence_transformer(monkeypatch)
+    docs = ["a small cat", "a friendly dog"]
+    store = VectorStore(docs)
+    results = store.search("canine", k=len(docs))
+    assert results[0] == docs[1]
+    assert store.dim == 2


### PR DESCRIPTION
## Summary
- replace custom byte embeddings with SentenceTransformer-backed vectors in `VectorStore` and lazily init model
- capture embedding dimensionality from model
- add tests for semantic search using patched SentenceTransformer stubs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a3788257c8329b8099543e2b90cd9