### PR TITLE
Handle Railway routing for worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ OPENAI_API_KEY=...
 ARIANNA_SERVER_TOKEN=...
 ```
 
+The worker automatically constructs `ARIANNA_SERVER_URL` using Railway's
+`RAILWAY_STATIC_URL`/`RAILWAY_URL` variables when available. Set
+`ARIANNA_SERVER_URL` (and `ARIANNA_SERVER_SSE_URL`) manually if you deploy
+outside Railway or need a custom endpoint.
+
 Then:
 
 ```

--- a/arianna_core/config.py
+++ b/arianna_core/config.py
@@ -45,6 +45,23 @@ def _tuple(v: str) -> Tuple[str, ...]:
     return tuple(x.strip() for x in v.split(";") if x.strip())
 
 
+def _railway_host() -> str | None:
+    host = os.getenv("RAILWAY_STATIC_URL") or os.getenv("RAILWAY_URL")
+    if host:
+        return host if host.startswith("http") else f"https://{host}"
+    return None
+
+
+def _default_server_url() -> str:
+    host = _railway_host()
+    return f"{host.rstrip('/')}/generate" if host else "http://127.0.0.1:8000/generate"
+
+
+def _default_server_sse_url() -> str:
+    host = _railway_host()
+    return f"{host.rstrip('/')}/generate_sse" if host else "http://127.0.0.1:8000/generate_sse"
+
+
 @dataclass(frozen=True)
 class Settings:
     """Container for environment configuration."""
@@ -59,13 +76,11 @@ class Settings:
         default_factory=lambda: _get_env("ARIANNA_SERVER_TOKEN", "")
     )
     arianna_server_url: str = field(
-        default_factory=lambda: _get_env(
-            "ARIANNA_SERVER_URL", "http://127.0.0.1:8000/generate"
-        )
+        default_factory=lambda: _get_env("ARIANNA_SERVER_URL", _default_server_url())
     )
     arianna_server_sse_url: str = field(
         default_factory=lambda: _get_env(
-            "ARIANNA_SERVER_SSE_URL", "http://127.0.0.1:8000/generate_sse"
+            "ARIANNA_SERVER_SSE_URL", _default_server_sse_url()
         )
     )
     telegram_token: str | None = field(

--- a/server.py
+++ b/server.py
@@ -52,7 +52,8 @@ if not settings.openai_api_key:
 # ────────────────────────────────────────────────────────────────────────────────
 # Конфиг
 # ────────────────────────────────────────────────────────────────────────────────
-SECRET               = settings.arianna_server_token
+def _secret() -> str:
+    return os.getenv("ARIANNA_SERVER_TOKEN", settings.arianna_server_token)
 MODEL_DEFAULT        = settings.arianna_model
 MODEL_LIGHT          = settings.arianna_model_light or MODEL_DEFAULT
 MODEL_HEAVY          = settings.arianna_model_heavy or MODEL_DEFAULT
@@ -85,9 +86,10 @@ def _extract_auth_token() -> str:
 def require_auth(fn: Callable):
     @wraps(fn)
     def inner(*args, **kwargs):
-        if SECRET:
+        secret = _secret()
+        if secret:
             token = _extract_auth_token()
-            if token != SECRET:
+            if token != secret:
                 return jsonify({"error": "unauthorized"}), 401
         return fn(*args, **kwargs)
     return inner


### PR DESCRIPTION
## Summary
- Derive server URLs from Railway-provided environment variables when available
- Read server auth token dynamically so tests and runtime config pick up changes
- Clarify Railway deployment docs for worker URL configuration

## Testing
- `flake8 --max-line-length 119 server.py arianna_core/config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a449bbb948329952c50b98fdb3e88