### PR TITLE
Handle Telegram updates without messages

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,15 @@
+import asyncio
+import types
+
+from main import handle_message
+
+
+class DummyContext:
+    pass
+
+
+def test_handle_message_without_message():
+    update = types.SimpleNamespace(message=None, effective_message=None)
+    ctx = DummyContext()
+    # Should not raise
+    asyncio.run(handle_message(update, ctx))


### PR DESCRIPTION
## Summary
- avoid crashes when Telegram updates contain no message
- add regression test for missing-message update

## Testing
- `flake8 main.py tests/test_main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4ad96364c83298114425aacf0cd2f