### PR TITLE
Handle missing Telegram token without crashing worker

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 import asyncio
 import types
 
-from main import handle_message
+from main import _build_application, _idle_until_cancelled, handle_message
 
 
 class DummyContext:
@@ -13,3 +13,17 @@ def test_handle_message_without_message():
     ctx = DummyContext()
     # Should not raise
     asyncio.run(handle_message(update, ctx))
+
+
+def test_build_application_without_token():
+    assert _build_application(None) is None
+
+
+def test_idle_until_cancelled_handles_cancellation():
+    async def runner():
+        task = asyncio.create_task(_idle_until_cancelled(sleep_interval=0.01))
+        await asyncio.sleep(0.02)
+        task.cancel()
+        await task
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- keep the Telegram worker alive but idle when `TELEGRAM_TOKEN` is absent instead of raising
- factor out helper utilities for building the Telegram application and cover them with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2abdc65a88329aa949e98eb15574b